### PR TITLE
Recommend pop-hp-wallpapers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,8 @@ Depends:
   systemd,
   ${misc:Depends},
   ${shlibs:Depends}
+Recommends:
+  pop-hp-wallpapers
 Description: HP vendor support
 
 Package: pop-hp-vendor-dkms


### PR DESCRIPTION
This makes it easier to only install pop-hp-vendor, and have everything else come in automatically