### PR TITLE
Implement temperature event

### DIFF
--- a/DataUploadRequestModel.json
+++ b/DataUploadRequestModel.json
@@ -1708,10 +1708,7 @@
                 "num_samples",
                 "cpu_zone_ptile",
                 "chg_zone_ptile",
-                "ext_zone_ptile",
-                "bat_zone_dc_ptile",
-                "bat_zone_ac_charging_ptile",
-                "bat_zone_ac_not_charging_ptile"
+                "ext_zone_ptile"
             ],
             "additionalProperties": false
         },

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -106,7 +106,9 @@ pub fn run() {
     let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap();
     timer
         .set(
-            Expiration::Interval(TimeSpec::from_duration(Duration::from_secs(10))),
+            Expiration::Interval(TimeSpec::from_duration(Duration::from_secs(
+                util::TEMP_SAMPLE_SECONDS as u64,
+            ))),
             TimerSetTimeFlags::empty(),
         )
         .unwrap();
@@ -250,7 +252,6 @@ pub fn run() {
                         if let Some(temps) = sensors.thermal() {
                             // println!("Temps: {:?}", temps);
                             db.insert_temps(&temps).unwrap();
-                            // XXX frequency
                         }
                     }
                 }

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -249,6 +249,8 @@ pub fn run() {
                         }
                         if let Some(temps) = sensors.thermal() {
                             // println!("Temps: {:?}", temps);
+                            db.insert_temps(&temps).unwrap();
+                            // XXX frequency
                         }
                     }
                 }

--- a/src/cli/daily.rs
+++ b/src/cli/daily.rs
@@ -22,7 +22,7 @@ pub fn run() {
 
     let mut insert_statement = db.prepare_queue_insert().unwrap();
     loop {
-        let temps = db.get_temps().unwrap();
+        let temps = db.get_temps(true).unwrap();
         if temps.len() < 100 {
             break;
         }

--- a/src/cli/daily.rs
+++ b/src/cli/daily.rs
@@ -19,4 +19,16 @@ pub fn run() {
         crate::update_events_and_queue(&db, &freqs, SamplingFrequency::Weekly).unwrap();
         db.update_last_weekly_time().unwrap();
     }
+
+    let mut insert_statement = db.prepare_queue_insert().unwrap();
+    loop {
+        let temps = db.get_temps().unwrap();
+        if temps.len() < 100 {
+            break;
+        }
+        insert_statement
+            .execute(&util::sumarize_temps(&temps).into())
+            .unwrap();
+        db.remove_temps_before(temps.last().unwrap()).unwrap();
+    }
 }

--- a/src/cli/print.rs
+++ b/src/cli/print.rs
@@ -25,8 +25,9 @@ pub fn run(mut args: env::Args) {
         Some("purposes") => println!("{:#?}", crate::purposes(&db, api(&db).as_ref())),
         Some("queued") => println!("{:#?}", db.get_queued().unwrap().1),
         Some("state") => println!("{:#?}", db.get_state(db::State::All).unwrap()),
+        Some("temps") => println!("{:#?}", db.get_temps(false).unwrap()),
         _ => {
-            eprintln!("Usage: hp-vendor print (consent|frequencies|purposes|queued|state)");
+            eprintln!("Usage: hp-vendor print (consent|frequencies|purposes|queued|state|temps)");
             process::exit(1);
         }
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -385,8 +385,8 @@ impl DB {
         let mut stmt = if limit {
             self.0.prepare(
                 "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
-                 LIMIT 100
-                 ORDER BY time",
+                 ORDER BY time
+                 LIMIT 100",
             )?
         } else {
             self.0.prepare(

--- a/src/db.rs
+++ b/src/db.rs
@@ -381,12 +381,19 @@ impl DB {
         Ok(())
     }
 
-    pub fn get_temps(&self) -> Result<Vec<util::Temps>> {
-        let mut stmt = self.0.prepare(
-            "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
+    pub fn get_temps(&self, limit: bool) -> Result<Vec<util::Temps>> {
+        let mut stmt = if limit {
+            self.0.prepare(
+                "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
                  LIMIT 100
                  SORT BY time",
-        )?;
+            )?
+        } else {
+            self.0.prepare(
+                "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
+                 SORT BY time",
+            )?
+        };
         let rows = stmt.query_map([], |row| {
             Ok(util::Temps {
                 cpu: row.get(0)?,

--- a/src/db.rs
+++ b/src/db.rs
@@ -386,12 +386,12 @@ impl DB {
             self.0.prepare(
                 "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
                  LIMIT 100
-                 SORT BY time",
+                 ORDER BY time",
             )?
         } else {
             self.0.prepare(
                 "SELECT cpu, ext, bat, chg, on_ac, charging, time FROM temps
-                 SORT BY time",
+                 ORDER BY time",
             )?
         };
         let rows = stmt.query_map([], |row| {

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,8 @@ pub mod drm;
 pub mod lock;
 pub mod nvme;
 pub mod pcie;
-pub mod sensors;
+mod sensors;
+pub use sensors::Sensors;
 pub mod systemd;
 
 pub use hp_vendor_client::conf::{hp_vendor_conf, HpVendorConf};

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ pub mod lock;
 pub mod nvme;
 pub mod pcie;
 mod sensors;
-pub use sensors::Sensors;
+pub use sensors::*;
 pub mod systemd;
 
 pub use hp_vendor_client::conf::{hp_vendor_conf, HpVendorConf};

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -51,7 +51,7 @@ fn percentiles(values: impl Iterator<Item = i64>) -> Vec<i64> {
     }
 
     let n = values.len() as i64;
-    let percentile = |p| values[div_ceil(p * n, 100) as usize];
+    let percentile = |p| values[div_ceil(p * n, 100) as usize - 1];
 
     vec![
         *values.first().unwrap(),

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -173,7 +173,7 @@ impl Sensors {
             let value = self
                 .hwmon_acpi_device
                 .attribute_value(format!("temp{}_input", n))?;
-            value.to_str()?.trim().parse().ok()
+            Some(value.to_str()?.trim().parse::<i64>().ok()? / 1000)
         };
 
         let on_ac = self.ac_device.attribute_value("online")?.to_str()?.trim() == "1";

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -51,7 +51,7 @@ fn percentiles(values: impl Iterator<Item = i64>) -> Vec<i64> {
     }
 
     let n = values.len() as i64;
-    let percentile = |p| div_ceil(p * n, 100);
+    let percentile = |p| values[div_ceil(p * n, 100) as usize];
 
     vec![
         *values.first().unwrap(),

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -5,44 +5,101 @@
 #[derive(Debug)]
 pub struct Temps {
     pub cpu: i64,
-    pub gpu: i64,
     pub ext: i64,
-    pub loc: i64,
     pub bat: i64,
     pub chg: i64,
+    pub on_ac: bool,
+    pub charging: bool,
 }
 
-pub fn fan() -> Option<i64> {
-    let mut enumerator = udev::Enumerator::new().ok()?;
-    enumerator.match_subsystem("hwmon").ok()?;
-    enumerator.match_attribute("name", "hp_vendor").ok()?;
-    let device = enumerator.scan_devices().ok()?.next()?;
-
-    device
-        .attribute_value("fan1_input")?
-        .to_str()?
-        .trim()
-        .parse()
-        .ok()
+#[derive(Debug)]
+pub struct Sensors {
+    ac_device: udev::Device,
+    bat_device: udev::Device,
+    hwmon_acpi_device: udev::Device,
+    hwmon_hp_device: udev::Device,
 }
 
-pub fn thermal() -> Option<Temps> {
-    let mut enumerator = udev::Enumerator::new().ok()?;
-    enumerator.match_subsystem("hwmon").ok()?;
-    enumerator.match_attribute("name", "acpitz").ok()?;
-    let device = enumerator.scan_devices().ok()?.next()?;
+impl Sensors {
+    pub fn new() -> Option<Self> {
+        let mut enumerator = udev::Enumerator::new().ok()?;
+        enumerator.match_subsystem("power_supply").ok()?;
+        enumerator.match_attribute("type", "Mains").ok()?;
+        let ac_device = enumerator.scan_devices().ok()?.next()?;
 
-    let temp_n = |n| {
-        let value = device.attribute_value(format!("temp{}_input", n))?;
-        value.to_str()?.trim().parse().ok()
-    };
+        let mut enumerator = udev::Enumerator::new().ok()?;
+        enumerator.match_subsystem("power_supply").ok()?;
+        enumerator.match_attribute("type", "Battery").ok()?;
+        let bat_device = enumerator.scan_devices().ok()?.next()?;
 
-    Some(Temps {
-        cpu: temp_n(1)?,
-        gpu: temp_n(2)?,
-        ext: temp_n(3)?,
-        loc: temp_n(4)?,
-        bat: temp_n(5)?,
-        chg: temp_n(6)?,
-    })
+        let mut enumerator = udev::Enumerator::new().ok()?;
+        enumerator.match_subsystem("hwmon").ok()?;
+        enumerator.match_attribute("name", "acpitz").ok()?;
+        let hwmon_acpi_device = enumerator.scan_devices().ok()?.next()?;
+
+        let mut enumerator = udev::Enumerator::new().ok()?;
+        enumerator.match_subsystem("hwmon").ok()?;
+        enumerator.match_attribute("name", "hp_vendor").ok()?;
+        let hwmon_hp_device = enumerator.scan_devices().ok()?.next()?;
+
+        Some(Self {
+            ac_device,
+            bat_device,
+            hwmon_acpi_device,
+            hwmon_hp_device,
+        })
+    }
+
+    // Doesn't seem to be a way to clear udev sysattr cache
+    pub fn update(&mut self) {
+        fn reopen(device: &udev::Device) -> Option<udev::Device> {
+            udev::Device::from_syspath(device.syspath()).ok()
+        }
+        if let Some(device) = reopen(&self.ac_device) {
+            self.ac_device = device;
+        }
+        if let Some(device) = reopen(&self.bat_device) {
+            self.bat_device = device;
+        }
+        if let Some(device) = reopen(&self.hwmon_acpi_device) {
+            self.hwmon_acpi_device = device;
+        }
+        if let Some(device) = reopen(&self.hwmon_hp_device) {
+            self.hwmon_hp_device = device;
+        }
+    }
+
+    pub fn fan(&self) -> Option<i64> {
+        self.hwmon_hp_device
+            .attribute_value("fan1_input")?
+            .to_str()?
+            .trim()
+            .parse()
+            .ok()
+    }
+
+    pub fn thermal(&self) -> Option<Temps> {
+        let temp_n = |n| {
+            let value = self
+                .hwmon_acpi_device
+                .attribute_value(format!("temp{}_input", n))?;
+            value.to_str()?.trim().parse().ok()
+        };
+
+        let on_ac = self.ac_device.attribute_value("online")?.to_str()?.trim() == "1";
+        let charging = self.bat_device.attribute_value("status")?.to_str()?.trim() == "Charging";
+
+        Some(Temps {
+            cpu: temp_n(1)?,
+            // Unused
+            // gpu: temp_n(2)?,
+            ext: temp_n(3)?,
+            // Unused
+            // loc: temp_n(4)?,
+            bat: temp_n(5)?,
+            chg: temp_n(6)?,
+            on_ac,
+            charging,
+        })
+    }
 }

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -6,6 +6,8 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::event;
 
+pub const TEMP_SAMPLE_SECONDS: i64 = 60;
+
 fn unix_time() -> i64 {
     OffsetDateTime::now_utc().unix_timestamp()
 }
@@ -74,7 +76,7 @@ pub fn sumarize_temps(temps: &[Temps]) -> event::ThermalSummary {
     let end_time = temps.last().unwrap().time;
     // Assume system up one minute per sample
     // TODO: better method
-    let system_up_time = temps.len() as i64 * 60;
+    let system_up_time = temps.len() as i64 * TEMP_SAMPLE_SECONDS;
 
     event::ThermalSummary {
         bat_zone_ac_charging_ptile: percentiles(

--- a/src/util/sensors.rs
+++ b/src/util/sensors.rs
@@ -42,18 +42,18 @@ fn div_ceil(lhs: i64, rhs: i64) -> i64 {
     }
 }
 
-fn percentiles(values: impl Iterator<Item = i64>) -> Vec<i64> {
+fn percentiles(values: impl Iterator<Item = i64>) -> Option<Vec<i64>> {
     let mut values = values.collect::<Vec<_>>();
     values.sort_unstable();
 
     if values.is_empty() {
-        return Vec::new();
+        return None;
     }
 
     let n = values.len() as i64;
     let percentile = |p| values[div_ceil(p * n, 100) as usize - 1];
 
-    vec![
+    Some(vec![
         *values.first().unwrap(),
         percentile(10),
         percentile(20),
@@ -65,7 +65,7 @@ fn percentiles(values: impl Iterator<Item = i64>) -> Vec<i64> {
         percentile(80),
         percentile(90),
         *values.last().unwrap(),
-    ]
+    ])
 }
 
 // `temps` must be sorted by time, and non-empty
@@ -92,10 +92,10 @@ pub fn sumarize_temps(temps: &[Temps]) -> event::ThermalSummary {
                 .map(|x| x.bat),
         ),
         bat_zone_dc_ptile: percentiles(temps.iter().filter(|x| !x.on_ac).map(|x| x.bat)),
-        chg_zone_ptile: percentiles(temps.iter().map(|x| x.chg)),
-        cpu_zone_ptile: percentiles(temps.iter().map(|x| x.cpu)),
+        chg_zone_ptile: percentiles(temps.iter().map(|x| x.chg)).unwrap(),
+        cpu_zone_ptile: percentiles(temps.iter().map(|x| x.cpu)).unwrap(),
         end_time: format_unix_time(end_time),
-        ext_zone_ptile: percentiles(temps.iter().map(|x| x.ext)),
+        ext_zone_ptile: percentiles(temps.iter().map(|x| x.ext)).unwrap(),
         num_samples: temps.len() as i64,
         start_time: format_unix_time(start_time),
         system_up_time,


### PR DESCRIPTION
This collects temperature samples in the `daemon`, and then in `daily` it calculates percentiles and queues an event for upload combing the data.

Fan and battery life events will also need sampling in the daemon in new database columns and aggregation into events like this.