### PR TITLE
Generate `BatteryLife` with dc/ac/charging times

### DIFF
--- a/src/cli/daily.rs
+++ b/src/cli/daily.rs
@@ -29,6 +29,9 @@ pub fn run() {
         insert_statement
             .execute(&util::sumarize_temps(&temps).into())
             .unwrap();
+        if let Some(battery_life) = util::sumarize_battery_life(&temps) {
+            insert_statement.execute(&battery_life.into()).unwrap();
+        }
         db.remove_temps_before(temps.last().unwrap()).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,29 +143,6 @@ pub fn event(type_: TelemetryEventType) -> Option<EventDesc> {
                 .into(),
             );
         }),
-        // TODO: generate in daemon
-        TelemetryEventType::HwBatteryLife => EventDesc::new(|events| {
-            let path = match battery() {
-                Some(path) => path,
-                None => return,
-            };
-
-            events.push(
-                event::BatteryLife {
-                    ct_number: read_file(path.join("battery_ct_number")).unwrap_or_else(unknown),
-                    cycle_count: read_file(path.join("cycle_count")).unwrap_or(-1),
-                    energy_full: read_file(path.join("charge_full"))
-                        .map(|x: i64| x / 1000)
-                        .unwrap_or(-1),
-                    serial_number: read_file(path.join("serial_number")).unwrap_or_else(unknown),
-                    timestamp: event::date_time(),
-                    total_ac_charging_time: None, // XXX
-                    total_ac_time: 0,             // XXX
-                    total_dc_time: 0,             // XXX
-                }
-                .into(),
-            );
-        }),
         TelemetryEventType::HwBaseBoard => EventDesc::new(|events| {
             events.push(
                 event::BaseBoard {


### PR DESCRIPTION
Uses the data from the `temps` table to generate this.

I was meaning to add fan data collection to this branch before PRing, but that's complicated as currently defined in the schema, so let's at least release this, which is simpler.

Testing for this should be similar to https://github.com/pop-os/hp-vendor/pull/9, since it just uses the same `temps` table. `BatteryLife` events were already generated, but daily with ac/dc time values set to 0. With this, they will be added at the same time as `ThermalSummary` events, with those values populated.