### PR TITLE
fix: Only generate remove events for event types that have a `state`

### DIFF
--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -208,10 +208,11 @@ pub fn run() {
                         } else if x.event_type() == udev::EventType::Remove {
                             if let Some(ids) = udev_devices.remove(x.syspath()) {
                                 let events = db.get_state(db::State::Ids(&ids)).unwrap();
-                                for mut event in events {
-                                    crate::event::remove_event(&mut event);
-                                    println!("{:#?}", event);
-                                    insert_statement.execute(&event).unwrap();
+                                for event in events {
+                                    if let Some(remove_event) = crate::event::remove_event(event) {
+                                        println!("{:#?}", remove_event);
+                                        insert_statement.execute(&remove_event).unwrap();
+                                    }
                                 }
                                 db.replace_state(db::State::Ids(&ids), &[]).unwrap();
                             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -139,16 +139,16 @@ impl<'a> Events<'a> {
     }
 }
 
-pub fn remove_event(event: &mut TelemetryEvent) {
-    if let Some(state) = event.state_mut() {
-        *state = State::Removed;
-    }
+pub fn remove_event(mut event: TelemetryEvent) -> Option<TelemetryEvent> {
+    *(event.state_mut()?) = State::Removed;
     event.clear_options();
 
-    if let TelemetryEvent::HwPeripheralUsb(event) = event {
+    if let TelemetryEvent::HwPeripheralUsb(event) = &mut event {
         event.timestamp = date_time();
     }
     // TODO: any other types with timestamp, etc.
+
+    Some(event)
 }
 
 pub fn diff(events: &mut Vec<TelemetryEvent>, old_events: &[TelemetryEvent]) {
@@ -184,9 +184,9 @@ pub fn diff(events: &mut Vec<TelemetryEvent>, old_events: &[TelemetryEvent]) {
     let mut new_events = Vec::new();
     for (k, old) in m2.iter_mut() {
         if !m1.contains_key(k) {
-            let mut new = (**old).clone();
-            remove_event(&mut new);
-            new_events.push(new);
+            if let Some(new) = remove_event((**old).clone()) {
+                new_events.push(new);
+            }
         }
     }
 


### PR DESCRIPTION
This produced invalid `hw_nvme_storage_logical` events on remove.